### PR TITLE
Fix misalignment between search button and search bar

### DIFF
--- a/styles/components/index.scss
+++ b/styles/components/index.scss
@@ -5,3 +5,4 @@
 @import "tag-list";
 @import "horizontal-list";
 @import "layout";
+@import "search";

--- a/styles/components/search.scss
+++ b/styles/components/search.scss
@@ -1,0 +1,10 @@
+.search {
+	input[type="search"],
+	input[type="submit"] {
+		height: 2.5rem;
+		vertical-align: middle;
+	}
+	input[type="search"] {
+		margin-bottom: 0;
+	}
+}


### PR DESCRIPTION
I found out that the search class is defined, but there is no SCSS file present for it. I created a file at /styles/component/search.scss and added styles so that all inputs inside the search component have a fixed height, regardless of border, margin, or padding differences.